### PR TITLE
Support separate PGN uploads and fix board display

### DIFF
--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Analysis</title>
-    <link rel="stylesheet" href="https://unpkg.com/cm-chessboard/styles/cm-chessboard.css"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/chessboard-js/1.0.0/chessboard.min.css" integrity="sha512-1PJ8wjYoB2ZUAMo6ckFELjaRyvOz1ivQAYdhbbQq3DYb8CxGtEiL+ptIpVc8D4KgcBJsIYX6OGpgCoHhXJDFJQ==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
     <style>
         body { font-family: sans-serif; max-width: 900px; margin:auto; padding:2em; }
         .board { width: 300px; height: 300px; }
@@ -20,21 +20,23 @@
   <button onclick="prev()">Previous</button>
   <button onclick="next()">Next</button>
 </div>
-<script type="module">
-import { Chessboard } from "https://unpkg.com/cm-chessboard/src/cm-chessboard/Chessboard.js";
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/chessboard-js/1.0.0/chessboard.min.js" integrity="sha512-0WexkLLdAYMt5C0/EQtYFq8QcPfrblu3Wkuk37lcH0YqhJ++cD27uYk2cEy/s8X3H559eCQ9L+R7r7BbK46+CQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script>
 const mistakes = {{ mistakes|tojson }};
 let index = 0;
-const board = new Chessboard(document.getElementById("board"), {
-    position: mistakes.length ? mistakes[0].fen : "",
-    style: {
-        aspectRatio: 1,
-        pieces: { file: "https://unpkg.com/cm-chessboard/assets/pieces/staunty.svg" }
-    }
+let board;
+$(function(){
+    board = Chessboard('board', {
+        position: mistakes.length ? mistakes[0].fen : 'start',
+        pieceTheme: 'https://cdnjs.cloudflare.com/ajax/libs/chessboard-js/1.0.0/img/chesspieces/wikipedia/{piece}.png'
+    });
+    show();
 });
 function show(){
     if(!mistakes.length) return;
     const m = mistakes[index];
-    board.setPosition(m.fen);
+    board.position(m.fen);
     document.getElementById("info").innerHTML = `<p>Frequency: ${m.game_count}</p><p>Your move: ${m.user_move}</p>`;
     document.getElementById("moveInput").value = "";
 }
@@ -47,7 +49,6 @@ function checkMove(){
 }
 function prev(){ if(index>0){ index--; show(); } }
 function next(){ if(index < mistakes.length-1){ index++; show(); } }
-show();
 </script>
 </body>
 </html>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -11,13 +11,27 @@
 </head>
 <body>
     <h1>Welcome {{ username }}</h1>
-    <p>Upload a <strong>.pgn</strong> file containing your games.</p>
+    <p>Upload <strong>.pgn</strong> files for your games. You may provide one or both files but at least one is required.</p>
     <div class="container">
-        <form action="/upload" method="post" enctype="multipart/form-data">
-            <input type="file" name="pgn_file" required>
+        <form action="/upload" method="post" enctype="multipart/form-data" onsubmit="return validate()">
+            <label>White games:<br><input type="file" name="white_pgn"></label>
+            <br>
+            <label>Black games:<br><input type="file" name="black_pgn"></label>
             <br>
             <input type="submit" value="Upload">
         </form>
+        {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
     </div>
+    <script>
+    function validate(){
+        const w = document.querySelector('input[name="white_pgn"]').value;
+        const b = document.querySelector('input[name="black_pgn"]').value;
+        if(!w && !b){
+            alert('Please select at least one PGN file.');
+            return false;
+        }
+        return true;
+    }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow uploading separate PGN files for white and black games
- merge all available PGNs during training
- use CDN chessboard assets to avoid binary files in the repo
- require at least one PGN on upload

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6858abe90ee08327a23623c256283f49